### PR TITLE
[iOS] Fix issue related to Main Thread Checker: UI API called on a background thread: -[UIApplication applicationState]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Capacitor plugin to open native settings screens for android and iOS
 ## Install
 
 ```bash
-npm install capacitor-native-settings
+npm install @trieutulong/capacitor-native-settings
 npx cap sync
 ```
 

--- a/TrieutulongCapacitorNativeSettings.podspec
+++ b/TrieutulongCapacitorNativeSettings.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorNativeSettings'
+  s.name = 'TrieutulongCapacitorNativeSettings'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
+++ b/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
@@ -1,9 +1,9 @@
 package nl.raphael.settings;
 
+import static android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS;
+
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
@@ -18,12 +18,26 @@ public class NativeSettingsPlugin extends Plugin {
         String option = call.getString("option");
         String setting = AndroidSettings.getAction(option);
 
+        // Check if settings is available.
         if (setting == null) {
             call.reject("Could not find native android setting: " + option);
             return;
         }
 
-        getActivity().startActivity(new Intent(setting));
+        Intent intent = new Intent();
+
+        // Application details requires package name as URI.
+        if (ACTION_APPLICATION_DETAILS_SETTINGS.equals(setting)) {
+            intent.setAction(setting);
+            intent.setData(Uri.parse("package:" + getActivity().getPackageName()));
+        } else {
+            intent.setAction(setting);
+        }
+
+        // Start intent in activity.
+        getActivity().startActivity(intent);
+
+        // Send response.
         JSObject js = new JSObject();
         js.put("status", true);
         call.resolve(js);

--- a/ios/Plugin/NativeSettingsPlugin.swift
+++ b/ios/Plugin/NativeSettingsPlugin.swift
@@ -8,26 +8,28 @@ import Capacitor
 @objc(NativeSettingsPlugin)
 public class NativeSettingsPlugin: CAPPlugin {
     @objc func openIOS(_ call: CAPPluginCall) {
-        let value = call.getString("option") ?? ""
-        var settingsUrl:URL!
-        
-        if (value == "general") {
-            settingsUrl = URL(string: "App-Prefs:root=General")
-        } else if (value == "app") {
-            settingsUrl = URL(string: UIApplication.openSettingsURLString)
-        } else {
-            call.reject("Requested setting \"" + value + "\" is not available on iOS.");
-            return
-        }
-
-        if UIApplication.shared.canOpenURL(settingsUrl) {
-            UIApplication.shared.open(settingsUrl, completionHandler: { (success) in
-                call.resolve([
-                    "status": success
-                ])
-            })
-        } else {
-            call.reject("Cannot open settings")
+        DispatchQueue.main.async {
+            let value = call.getString("option") ?? ""
+            var settingsUrl:URL!
+            
+            if (value == "general") {
+                settingsUrl = URL(string: "App-Prefs:root=General")
+            } else if (value == "app") {
+                settingsUrl = URL(string: UIApplication.openSettingsURLString)
+            } else {
+                call.reject("Requested setting \"" + value + "\" is not available on iOS.");
+                return
+            }
+            
+            if UIApplication.shared.canOpenURL(settingsUrl) {
+                UIApplication.shared.open(settingsUrl, completionHandler: { (success) in
+                    call.resolve([
+                        "status": success
+                    ])
+                })
+            } else {
+                call.reject("Cannot open settings")
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "capacitor-native-settings",
-  "version": "0.0.1",
+  "name": "@trieutulong/capacitor-native-settings",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@trieutulong/capacitor-native-settings",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trieutulong/capacitor-native-settings",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Capacitor plugin to open native settings screens for android and iOS",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "capacitor-native-settings",
-  "version": "0.0.1",
+  "name": "@trieutulong/capacitor-native-settings",
+  "version": "0.0.2",
   "description": "Capacitor plugin to open native settings screens for android and iOS",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorNativeSettings.podspec"
+    "TrieutulongCapacitorNativeSettings.podspec"
   ],
   "author": "Raphael vd Woude",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorNativeSettings',
+      name: 'TrieutulongCapacitorNativeSettings',
       globals: {
         '@capacitor/core': 'capacitorExports',
       },


### PR DESCRIPTION
When I call ` await NativeSettings.openIOS({ option: IOSSettings.App });`

I got the error message `UI API called on a background thread` from XCode and this error lead me to this answer from SO:
https://stackoverflow.com/a/45913510/1979190